### PR TITLE
Please improve how you specify the license

### DIFF
--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -12,9 +12,17 @@
 ;; xahk-mode - Author:   Xah Lee ( http://xahlee.org/ ) - 2012
 ;; ahk-mode - Author:   Robert Widhopf-Fenk
 
-;; You can redistribute this program and/or modify it under the terms of the GNU
-;; General Public License as published by the Free Software Foundation; either
-;; GPL version 2 or 3.
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or version 2.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
+;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
I am the maintainer of the [Emacsmirror](https://emacsmirror.org), which mirrors more than seven thousand Emacs packages.  Each package [is distributed](https://github.com/emacsmirror) as a Git repository.

Because I distribute these packages, I have to worry about how they are licensed.  Packages should be compatible with the license used by Emacs, i.e. version 3 of the GPL.  To ensure that this is the case I obviously have to detect the license.

I have written a library to do so called [`elx`](https://github.com/emacscollective/elx).  It can extract the license from the permission statement at the beginning of a "main" library, the `License` header at the beginning of the library, or the `LICENSE` file in the same repository.

In theory that should get the job done, but with more than 7000 packages we have to expect some issues.  Over the years `elx` therefore has been taught about variations of the default permission statements that are used in the wild and even many non-standard permission statements that, while possibly weird, still unambiguously identify the license.

Finally a handful of packages (15 out of 7328) specify the license in a way where even that is not enough. For these packages it was necessary to hardcode the license inside of `elx`.  

Unfortunately this package is one of them.

This pull-request changes how the license is specified, it does *not* change the license.

Also note that this is the standard license text except for:

```diff
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3.
+;; the Free Software Foundation; either version 3, or version 2.
```

(Please note that it is important that you change the order in which these two versions are specified like I have done here.  Otherwise `elx` would not detect that this is available under v3.)

However I recommend that you use the following instead:

```diff
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3, or version 2.
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
```

That however potentially changes the license: once version 4 of the GPL is released, users are free to receive this package under that license if they wish to do so.

I recommend that you do that because your package is the *only* package that allows "version N or version N+1" of the GPL.  All other packages use either "exactly version N" or "version N or any later version".