### PR TITLE
Several improvements to indentation

### DIFF
--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -344,9 +344,9 @@ Finds the command in the internal AutoHotkey documentation."
         (setq indent 0))
        (closing-brace
         (setq indent (- indent ahk-indentation)))
-       ;; if beginning with a comment, indent based on previous line
+       ;; if beginning with a comment, take its indentation
        ((looking-at "^\\([ \t]*\\);")
-        (setq indent (ahk-previous-indent)))
+        nil)
        ;; keybindings
        ((and (looking-at "^[ \t]*[^:\n ]+:$")
              (not label))

--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -345,7 +345,7 @@ Finds the command in the internal AutoHotkey documentation."
        (closing-brace
         (setq indent (- indent ahk-indentation)))
        ;; if beginning with a comment, indent based on previous line
-       ((looking-at "^\\([ \t*]\\);")
+       ((looking-at "^\\([ \t]*\\);")
         (setq indent (ahk-previous-indent)))
        ;; keybindings
        ((and (looking-at "^[ \t]*[^:\n ]+:$")

--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -384,6 +384,9 @@ Finds the command in the internal AutoHotkey documentation."
         (and
          (setq prev-single t)
          (setq indent (+ indent ahk-indentation))))
+       ((looking-at "^[ \t]*,[^\n]+[}]$")  ; last line of a multi-line list
+         (setq indent (- indent ahk-indentation)))
+
        ;; (return
        ;;  (setq indent (- indent ahk-indentation)))
        ;; subtract indentation if closing bracket only

--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -378,7 +378,7 @@ Finds the command in the internal AutoHotkey documentation."
              (not block-skip)
              ;; (or if-else loop)
              (or
-              (looking-at "^[ \t]*\\([Ll]oop\\)[^{=\n]*")
+              (looking-at "^[ \t]*\\([Ll]oop\\)[^{=]*\n")
               (looking-at "^\\([ \t]*\\)\\([iI]f\\|[eE]lse\\)[^{]*\n"))
              )
         (and
@@ -399,8 +399,8 @@ Finds the command in the internal AutoHotkey documentation."
              (not block-skip)
              (not empty-brace)
              (or
-              (looking-at "^[ \t]*\\([Ll]oop\\)[^{\n]+")
-              (looking-at "^\\([ 	]*\\)\\([iI]f\\|[eE]lse\\)[^{\n]+")))
+              (looking-at "^[ \t]*\\([Ll]oop\\)[^{]+\n")
+              (looking-at "^\\([ \t]*\\)\\([iI]f\\|[eE]lse\\)[^{]+\n")))
         ;; adjust when stacking multiple single line commands
         (setq indent (- indent (if prev-single (- (* 2 ahk-indentation)) 0) ahk-indentation)))
       )

--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -310,7 +310,7 @@ Finds the command in the internal AutoHotkey documentation."
       (setq opening-paren      (looking-at "^[ \t]*([^)]"))
       (setq if-else            (looking-at "^[ \t]*\\([iI]f\\|[Ee]lse\\)"))
       (setq loop            (looking-at "^[ \t]*\\([Ll]oop\\)[^{]+"))
-      (setq closing-brace      (looking-at "^[ \t]*\\([)}]\\|\\*\\/\\)$"))
+      (setq closing-brace      (looking-at "^[ \t]*\\([)}]\\|\\*\\/\\)"))  ; no "$" for the case of "} else {"
       (setq label              (looking-at "^[ \t]*[^:\n ]+:$"))
       (setq keybinding         (looking-at "^[ \t]*[^:\n ]+::\\(.*\\)$"))
       (setq return             (looking-at "^\\([ \t]*\\)[rR]eturn"))

--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -309,7 +309,7 @@ Finds the command in the internal AutoHotkey documentation."
       (setq opening-brace      (looking-at "^[ \t]*{[^}]"))
       (setq opening-paren      (looking-at "^[ \t]*([^)]"))
       (setq if-else            (looking-at "^[ \t]*\\([iI]f\\|[Ee]lse\\)"))
-      (setq loop            (looking-at "^[ \t]*\\([Ll]oop\\)[^{]+"))
+      (setq loop               (looking-at "^[ \t]*\\([Ll]oop\\)[^{]+"))
       (setq closing-brace      (looking-at "^[ \t]*\\([)}]\\|\\*\\/\\)"))  ; no "$" for the case of "} else {"
       (setq label              (looking-at "^[ \t]*[^:\n ]+:$"))
       (setq keybinding         (looking-at "^[ \t]*[^:\n ]+::\\(.*\\)$"))


### PR DESCRIPTION
ahk-mode now indents a 1800 line AHK script correctly for me.

* Correctly indent the line after a multi-line list
* Indentation now properly handles single-line If/Loop
* A line following a comment is now indented to the commented line (was indented to the previous line which did not work if that was an "if ..." for example)
* Indentation: fixed the "} else {" case
