### PR TITLE
Fix ahk-run-script

### DIFF
--- a/ahk-mode.el
+++ b/ahk-mode.el
@@ -199,8 +199,7 @@
   "Run the ahk-script in the current buffer."
   (interactive)
   (let ((file (shell-quote-argument
-               (replace-regexp-in-string " " "\ "
-                                         (replace-regexp-in-string "\/" "\\\\" (buffer-file-name) t t)))))
+	  (replace-regexp-in-string "\/" "\\\\" (buffer-file-name) t t))))
     (message "Executing script %s" file)
     (w32-shell-execute "open" file)))
 


### PR DESCRIPTION
ahk-run-script gave me the following error:
let: ShellExecute failed: The system cannot find the file specified.

Deleting the outer regexp fixes this issue for me.